### PR TITLE
Caps letters for namespace

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -3,9 +3,9 @@
  * Dependency services.
  */
 $di->set('signal_manager', function() use ($di) {
-    return $di->newInstance('aura\signal\Manager', array(
-        'handler_factory'   => $di->newInstance('aura\signal\HandlerFactory'),
-        'result_factory'    => $di->newInstance('aura\signal\ResultFactory'),
-        'result_collection' => new aura\signal\ResultCollection, // newInstance() fails with ArrayObject ?
+    return $di->newInstance('Aura\Signal\Manager', array(
+        'handler_factory'   => $di->newInstance('Aura\Signal\HandlerFactory'),
+        'result_factory'    => $di->newInstance('Aura\Signal\ResultFactory'),
+        'result_collection' => new Aura\Signal\ResultCollection, // newInstance() fails with ArrayObject ?
     ));
 });

--- a/scripts/instance.php
+++ b/scripts/instance.php
@@ -1,4 +1,4 @@
 <?php
-namespace aura\signal;
+namespace Aura\Signal;
 require dirname(__DIR__) . '/src.php';
 return new Manager(new HandlerFactory, new ResultFactory, new ResultCollection);

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * Generic package exception.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class Exception extends \Exception {}

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * A signal Handler definition.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class Handler

--- a/src/HandlerFactory.php
+++ b/src/HandlerFactory.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * A factory to create Handler objects.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class HandlerFactory

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * Processes signals through to Handler objects.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class Manager
@@ -24,7 +24,7 @@ class Manager
      * @const string
      * 
      */
-    const STOP = 'aura\signal\Manager::STOP';
+    const STOP = 'Aura\Signal\Manager::STOP';
     
     /**
      * 

--- a/src/Result.php
+++ b/src/Result.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * Represents a Result from a Handler.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class Result

--- a/src/ResultCollection.php
+++ b/src/ResultCollection.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * Represents a collection of Result objects.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class ResultCollection extends \ArrayObject

--- a/src/ResultFactory.php
+++ b/src/ResultFactory.php
@@ -6,13 +6,13 @@
  * @license http://opensource.org/licenses/bsd-license.php BSD
  * 
  */
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * 
  * A factory to create Result objects.
  * 
- * @package aura.signal
+ * @package Aura.Signal
  * 
  */
 class ResultFactory

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * Test class for Handler.

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * Test class for Manager.

--- a/tests/ResultCollectionTest.php
+++ b/tests/ResultCollectionTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * Test class for ResultCollection.

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace aura\signal;
+namespace Aura\Signal;
 
 /**
  * Test class for Result.
@@ -48,7 +48,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
             'value'   => $value,
         ));
         
-        $this->assertType('aura\signal\Result', $result);
+        $this->assertType('Aura\Signal\Result', $result);
         $this->assertSame($result->origin, $origin);
         $this->assertSame($result->sender, $sender);
         $this->assertSame($result->signal, $signal);


### PR DESCRIPTION
Hi pmjones, 
I spend sometime to change the namespace from small letters to caps for aura.di , aura.cli, aura.signal . But I was not able to run the test for the system needs more changes :( . 
In case if you need you can look into these pull requests.

Thank You
