### PR TITLE
fix the typo in example's namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Stopping Signal Processing
 --------------------------
 
 Sometimes it will be necessary to stop processing signal handlers. If a
-handler callback returns the `aura\signal\Manager::STOP` constant, then no
+handler callback returns the `Aura\Signal\Manager::STOP` constant, then no
 more handlers for that signal will be processed.
 
 First we define the handlers; note that the second one returns the `STOP`


### PR DESCRIPTION
@pmjones I have a question also . The manager currently have a `STOP` , but what about a start after a `STOP` ? I feel there is a need.
