### PR TITLE
added match on origin

### DIFF
--- a/src/Aura/Signal/Handler.php
+++ b/src/Aura/Signal/Handler.php
@@ -105,10 +105,8 @@ class Handler
             // match on a specific object
             $match_sender = $this->sender === $origin;
         } else {
-            // match on a wildcard or an origin
-            $match_sender = $this->sender == '*' || $this->sender == $origin;
-            // match on a parent class
-            $match_sender = $match_sender || $origin instanceof $this->sender;
+            // match on a wildcard or an origin or a parent class
+            $match_sender = $this->sender == '*' || $this->sender == $origin || $origin instanceof $this->sender;
         }
 
         // match on a signal

--- a/src/Aura/Signal/Handler.php
+++ b/src/Aura/Signal/Handler.php
@@ -105,8 +105,10 @@ class Handler
             // match on a specific object
             $match_sender = $this->sender === $origin;
         } else {
-            // match on a class
-            $match_sender = $this->sender == '*' || $origin instanceof $this->sender;
+            // match on a wildcard or an origin
+            $match_sender = $this->sender == '*' || $this->sender == $origin;
+            // match on a parent class
+            $match_sender = $match_sender || $origin instanceof $this->sender;
         }
 
         // match on a signal

--- a/tests/Aura/Signal/HandlerTest.php
+++ b/tests/Aura/Signal/HandlerTest.php
@@ -98,4 +98,25 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
         $params = $handler->exec($origin, 'wrong_signal', ['hello']);
         $this->assertNull($params);
     }
+    
+    public function testExecOnSameString()
+    {
+        $handler = $this->newHandler('some text');
+
+        // this should be a match
+        $origin = 'some text';
+        $params = $handler->exec($origin, 'mock_signal', ['hello']);
+        $this->assertSame('hello!!!', $params['value']);
+        $this->assertSame($origin, $params['origin']);
+
+        // this should not be a match
+        $origin = 'another text';
+        $params = $handler->exec($origin, 'mock_signal', ['hello']);
+        $this->assertNull($params);
+
+        // this should not be a match
+        $origin = new \StdClass;
+        $params = $handler->exec($origin, 'mock_signal', ['hello']);
+        $this->assertNull($params);
+    }
 }


### PR DESCRIPTION
it allows to use non-class related matching. I found it very useful to apply same pre/post action tasks for different classes.
