### PR TITLE
add capability to use a lazy object initialization

### DIFF
--- a/src/Aura/Signal/Handler.php
+++ b/src/Aura/Signal/Handler.php
@@ -115,8 +115,10 @@ class Handler
         // do the sender and signal match?
         if ($match_sender && $match_signal) {
             // yes, return an array of params with the callback return value
-            if (is_object($this->callback[0]) && get_class($this->callback[0]) == 'Aura\Di\LazyNew') {
-                $this->callback[0] = $this->callback[0]->__invoke();
+            if (is_array($this->callback) && is_object($this->callback[0])
+                && !method_exists($this->callback[0], $this->callback[1])) {
+                // probably it's a lazy object
+                $this->callback[0] = $this->callback[0]();
             }
             return [
                 'origin' => $origin,

--- a/src/Aura/Signal/Handler.php
+++ b/src/Aura/Signal/Handler.php
@@ -115,6 +115,9 @@ class Handler
         // do the sender and signal match?
         if ($match_sender && $match_signal) {
             // yes, return an array of params with the callback return value
+            if (is_object($this->callback[0]) && get_class($this->callback[0]) == 'Aura\Di\LazyNew') {
+                $this->callback[0] = $this->callback[0]->__invoke();
+            }
             return [
                 'origin' => $origin,
                 'sender' => $this->sender,


### PR DESCRIPTION
it allows to define handler with Aura\Di\LazyNew object to avoid object initialization until signal matched.
In my project I'm using aura\signal to define task chains (config define/modify, pre-action/post-action).  I found it very flexible and useful to develop lego-like apps. Unfortunately, the current Signal implementation doesn't allow to use lazy object initialization. This patch fixes it.
